### PR TITLE
[Refactor/SWM-233] 닉네임 중복 커스텀 에러 처리 추가

### DIFF
--- a/src/main/java/com/example/tripmingle/adapter/in/AuthController.java
+++ b/src/main/java/com/example/tripmingle/adapter/in/AuthController.java
@@ -5,13 +5,12 @@ import static com.example.tripmingle.common.result.ResultCode.*;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.tripmingle.common.result.ResultResponse;
-import com.example.tripmingle.dto.req.auth.ValidateDuplicationReqDTO;
 import com.example.tripmingle.dto.res.auth.TokenDTO;
 import com.example.tripmingle.dto.res.auth.ValidateDuplicationResDTO;
 import com.example.tripmingle.port.in.AuthUseCase;
@@ -31,9 +30,8 @@ public class AuthController {
 	@Operation(summary = "닉네임 중복 여부 확인")
 	@GetMapping("/validate/duplication")
 	public ResponseEntity<ResultResponse> validateDuplication(
-		@RequestBody ValidateDuplicationReqDTO validateDuplicationReqDTO) {
-		ValidateDuplicationResDTO validateDuplicationResDTO = authUseCase.validateDuplication(
-			validateDuplicationReqDTO);
+		@RequestParam("nickName") String nickName) {
+		ValidateDuplicationResDTO validateDuplicationResDTO = authUseCase.validateDuplication(nickName);
 		return ResponseEntity.ok(ResultResponse.of(VALIDATE_COMPLETE, validateDuplicationResDTO));
 	}
 

--- a/src/main/java/com/example/tripmingle/application/facadeService/AuthFacadeService.java
+++ b/src/main/java/com/example/tripmingle/application/facadeService/AuthFacadeService.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service;
 
 import com.example.tripmingle.application.service.AuthService;
 import com.example.tripmingle.application.service.UserService;
-import com.example.tripmingle.dto.req.auth.ValidateDuplicationReqDTO;
 import com.example.tripmingle.dto.res.auth.LogoutResDTO;
 import com.example.tripmingle.dto.res.auth.TokenDTO;
 import com.example.tripmingle.dto.res.auth.ValidateDuplicationResDTO;
@@ -21,8 +20,8 @@ public class AuthFacadeService implements AuthUseCase {
 	private final UserService userService;
 
 	@Override
-	public ValidateDuplicationResDTO validateDuplication(ValidateDuplicationReqDTO validateDuplicationReqDTO) {
-		return authService.validateDuplication(validateDuplicationReqDTO);
+	public ValidateDuplicationResDTO validateDuplication(String nickName) {
+		return authService.validateDuplication(nickName);
 	}
 
 	@Override

--- a/src/main/java/com/example/tripmingle/application/service/AuthService.java
+++ b/src/main/java/com/example/tripmingle/application/service/AuthService.java
@@ -6,7 +6,6 @@ import com.example.tripmingle.common.error.ErrorCode;
 import com.example.tripmingle.common.exception.ExpiredRefreshTokenException;
 import com.example.tripmingle.common.exception.InvalidUserAccessException;
 import com.example.tripmingle.common.utils.JwtUtils;
-import com.example.tripmingle.dto.req.auth.ValidateDuplicationReqDTO;
 import com.example.tripmingle.dto.res.auth.TokenDTO;
 import com.example.tripmingle.dto.res.auth.ValidateDuplicationResDTO;
 import com.example.tripmingle.entity.User;
@@ -23,8 +22,9 @@ public class AuthService {
 	private final UserPersistPort userPersistPort;
 	private final RefreshPort refreshPort;
 
-	public ValidateDuplicationResDTO validateDuplication(ValidateDuplicationReqDTO validateDuplicationReqDTO) {
-		boolean duplicationStatus = userPersistPort.existsByNickName(validateDuplicationReqDTO.getNickName());
+	public ValidateDuplicationResDTO validateDuplication(String nickName) {
+		boolean duplicationStatus = userPersistPort.existsByNickName(nickName);
+		System.out.println(duplicationStatus);
 		return ValidateDuplicationResDTO.builder()
 			.duplicationStatus(duplicationStatus)
 			.build();

--- a/src/main/java/com/example/tripmingle/common/error/ErrorCode.java
+++ b/src/main/java/com/example/tripmingle/common/error/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
 	// user
 	USER_NOT_FOUND(404, "U001", "해당 유저가 존재하지 않습니다."),
 	INVALID_USER_ACCESS(403, "U002", "해당 유저에 권한이 없습니다."),
+	ALREADY_EXISTS_USER_NICKNAME(403, "U003", "이미 존재하는 닉네임입니다."),
 
 	// posting
 	POSING_NOT_FOUND(404, "P001", "해당 포스팅글이 존재하지 않습니다."),

--- a/src/main/java/com/example/tripmingle/common/exception/NickNameDuplicationException.java
+++ b/src/main/java/com/example/tripmingle/common/exception/NickNameDuplicationException.java
@@ -1,0 +1,16 @@
+package com.example.tripmingle.common.exception;
+
+import com.example.tripmingle.common.error.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class NickNameDuplicationException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public NickNameDuplicationException(String message, ErrorCode errorCode) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/example/tripmingle/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/tripmingle/common/exception/handler/GlobalExceptionHandler.java
@@ -26,6 +26,7 @@ import com.example.tripmingle.common.exception.JsonParsingException;
 import com.example.tripmingle.common.exception.LeaderCannotLeaveException;
 import com.example.tripmingle.common.exception.LogoutUserException;
 import com.example.tripmingle.common.exception.MatchingServerException;
+import com.example.tripmingle.common.exception.NickNameDuplicationException;
 import com.example.tripmingle.common.exception.OneOnOneChatRoomNotFoundException;
 import com.example.tripmingle.common.exception.PostingCommentNotFoundException;
 import com.example.tripmingle.common.exception.PostingLikesNotFoundException;
@@ -256,6 +257,13 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(ExpiredRefreshTokenException.class)
 	public ResponseEntity<ErrorResponse> handleExpiredRefreshTokenException(ExpiredRefreshTokenException ex) {
 		log.error("handleExpiredRefreshTokenException", ex);
+		final ErrorResponse response = new ErrorResponse(ex.getErrorCode());
+		return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getErrorCode().getStatus()));
+	}
+
+	@ExceptionHandler(NickNameDuplicationException.class)
+	public ResponseEntity<ErrorResponse> handleNickNameDuplicationException(NickNameDuplicationException ex) {
+		log.error("handleNickNameDuplicationException", ex);
 		final ErrorResponse response = new ErrorResponse(ex.getErrorCode());
 		return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getErrorCode().getStatus()));
 	}

--- a/src/main/java/com/example/tripmingle/port/in/AuthUseCase.java
+++ b/src/main/java/com/example/tripmingle/port/in/AuthUseCase.java
@@ -1,13 +1,12 @@
 package com.example.tripmingle.port.in;
 
-import com.example.tripmingle.dto.req.auth.ValidateDuplicationReqDTO;
 import com.example.tripmingle.dto.res.auth.LogoutResDTO;
 import com.example.tripmingle.dto.res.auth.TokenDTO;
 import com.example.tripmingle.dto.res.auth.ValidateDuplicationResDTO;
 
 public interface AuthUseCase {
 
-	ValidateDuplicationResDTO validateDuplication(ValidateDuplicationReqDTO validateDuplicationReqDTO);
+	ValidateDuplicationResDTO validateDuplication(String nickName);
 
 	LogoutResDTO logout();
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!--
[점검사항]
1. 제목 양식
2. Development 이슈 링크 걸기
3. Labels 태그 설정하기
4. 방금 작성한 코드가 최선일까 고민해보기
-->
### Issue Link
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- close refactor/SWM-233

### 핵심 내용
<!-- 무엇을 했는가 -->
- 닉네임 중복 커스텀 에러 처리 추가

### 스크린샷 (선택)
-

### 전달 사항 (선택)
<!-- Code Review시 얘기를 나누고 싶은 내용 -->
DataIntegrityViolationException 는 rumtimeexception 이다 따라서 try catch 를 하지 않아도 된다. 하지만 트랜잭션 내부에서 runtimeexception 이 발생하면 default 로 rollback 처리가 되면서 RollbackException 이 발생하게 된다. RollbackException 또한 runtimeException 이므로 결국 try catch 자체를 할 필요가 없어진다.
결론적으로는 uncheckexception 이므로 상위 클래스로 전파할 필요가 없다.
하지만 커스텀 에러로 던져주고 싶다면 try catch 로 잡아 나의 custom 예외로 감싸서 던져주는 것도 하나의 방법이다.

참고 : https://velog.io/@yhlee9753/%EC%9C%A0%EB%8B%88%ED%81%AC-%EC%A0%9C%EC%95%BD-%EC%A1%B0%EA%B1%B4-%EC%98%88%EC%99%B8%EC%B2%98%EB%A6%AC-su8mgmkc
